### PR TITLE
Schedule fix

### DIFF
--- a/ecosystem/group-by-pattern.json
+++ b/ecosystem/group-by-pattern.json
@@ -11,7 +11,7 @@
         "rome"
       ],
       "groupName": "lint and formatters",
-      "schedule": ["on the fist saturday every month"]
+      "schedule": ["on the first saturday every month"]
     },
     {
       "matchPackagePatterns": ["^sanity", "^@sanity", "^@portabletext/"],
@@ -61,7 +61,7 @@
     {
       "matchPackagePatterns": ["^@types/"],
       "groupName": "types packages",
-      "schedule": ["on the fist saturday every month"]
+      "schedule": ["on the first saturday every month"]
     },
     {
       "matchPackagePatterns": ["^@vitejs", "^vite"],

--- a/ecosystem/lock-file-maintenance.json
+++ b/ecosystem/lock-file-maintenance.json
@@ -4,6 +4,6 @@
   "lockFileMaintenance": {
     "dependencyDashboardApproval": true,
     "enabled": true,
-    "schedule": ["every 3 months on the first day of the month"]
+    "schedule": ["every 3 months on the first saturday of the month"]
   }
 }

--- a/ecosystem/schedule.json
+++ b/ecosystem/schedule.json
@@ -5,7 +5,7 @@
   ],
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["every 3 months on the first day of the month"]
+    "schedule": ["every 3 months on the first saturday of the month"]
   },
   "packageRules": [
     {

--- a/ecosystem/schedule.json
+++ b/ecosystem/schedule.json
@@ -5,7 +5,7 @@
   ],
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["quarterly"]
+    "schedule": ["every 3 months on the first day of the month"]
   },
   "packageRules": [
     {

--- a/ecosystem/security.json
+++ b/ecosystem/security.json
@@ -5,7 +5,7 @@
     {
       "description": "Pin `github-action` digests. As per GitHubs [security best practice](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)",
       "excludePackagePrefixes": ["actions/", "github/"],
-      "schedule": ["every 3 months on the first day of the month"],
+      "schedule": ["every 3 months on the first saturday of the month"],
       "matchDepTypes": ["action"],
       "pinDigests": true
     }

--- a/ecosystem/security.json
+++ b/ecosystem/security.json
@@ -5,7 +5,7 @@
     {
       "description": "Pin `github-action` digests. As per GitHubs [security best practice](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)",
       "excludePackagePrefixes": ["actions/", "github/"],
-      "schedule": ["quarterly"],
+      "schedule": ["every 3 months on the first day of the month"],
       "matchDepTypes": ["action"],
       "pinDigests": true
     }


### PR DESCRIPTION
Skrivefeil i schedule for types og linters gjør at denne går hver lørdag istedenfor én gang i mnd.
Renovate kjenner ikke igjen `quarterly`, men kan fikses ved å sette `"schedule": ["schedule:quarterly"]` for å bruke presetet. Da får vi derimot schedule hver første dag i mnd, men siden vi vil ha lørdager må denne spesifiseres.