### PR TITLE
Add groq to sanity group

### DIFF
--- a/ecosystem/group-by-pattern.json
+++ b/ecosystem/group-by-pattern.json
@@ -14,7 +14,7 @@
       "schedule": ["on the fist saturday every month"]
     },
     {
-      "matchPackagePatterns": ["^sanity", "^@sanity", "^@portabletext/"],
+      "matchPackagePatterns": ["^sanity", "^@sanity", "^@portabletext/", "^groq"],
       "groupName": "sanity packages"
     },
     {


### PR DESCRIPTION
I banken bruker vi `groq` fra Sanity i studioet vårt for å skrive queries. Next-sanity har dette i frontend, men i studio må vi bruke groq-pakka til Sanity. Hadde vært veldig smud å fått denne inn i samme gruppe da den alltid følger samme versjon som `sanity`.