### PR TITLE
group happy-dom packages

### DIFF
--- a/ecosystem/group-by-pattern.json
+++ b/ecosystem/group-by-pattern.json
@@ -11,6 +11,10 @@
       "groupName": "sanity packages"
     },
     {
+      "matchPackagePatterns": ["^@happy-dom/", "^happy-dom"],
+      "groupName": "happy-dom packages"
+    },
+    {
       "matchPackagePatterns": ["^@obosbbl/grunnmuren-", "^tailwindcss"],
       "groupName": "design system packages"
     },


### PR DESCRIPTION
Add rule to group happy-dom dependencies together into a single PR.

Goal:
Turn these two PRs into a single one.

<img width="810" alt="Screenshot 2024-02-06 at 12 55 37" src="https://github.com/code-obos/dkt-renovate-presets/assets/81577/21de2818-416a-40a5-b32c-a8681d804a53">
