### PR TITLE
group react-aria-packages

### DIFF
--- a/ecosystem/group-by-pattern.json
+++ b/ecosystem/group-by-pattern.json
@@ -11,6 +11,10 @@
       "groupName": "sanity packages"
     },
     {
+      "matchPackagePatterns": ["^@react-aria/", "^react-aria"],
+      "groupName": "react-aria packages"
+    },
+    {
       "matchPackagePatterns": ["^@happy-dom/", "^happy-dom"],
       "groupName": "happy-dom packages"
     },


### PR DESCRIPTION
I grunnmuren repoet ser jeg at Renovate kommer til åpne to forskjellige PRer , en for react-aria-components og en for @react-aria/utils (se første og siste punkt i lista i bildet). Jeg har lyst til at disse skal grupperes sammen.


<img width="465" alt="Screenshot 2024-02-16 at 09 20 45" src="https://github.com/code-obos/dkt-renovate-presets/assets/81577/26da125b-e658-4510-8678-56459e864fbf">
