### PR TITLE
Pin github actions digests to semver

### DIFF
--- a/ecosystem/security.json
+++ b/ecosystem/security.json
@@ -3,11 +3,12 @@
   "description": "Recommended rules that aid in hardening security. Which is more important the more you automate things.",
   "packageRules": [
     {
+      "extends": ["helpers:pinGitHubActionDigests"],
       "description": "Pin `github-action` digests. As per GitHubs [security best practice](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)",
       "excludePackagePrefixes": ["actions/", "github/"],
-      "schedule": ["on saturday on the first week of the month every 3rd month"],
-      "matchDepTypes": ["action"],
-      "pinDigests": true
+      "extractVersion": "^(?<version>v\\d+\\.\\d+\\.\\d+)$",
+      "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$",
+      "schedule": ["on saturday on the first week of the month every 3rd month"]
     }
   ]
 }


### PR DESCRIPTION
La oss prøve på dette. Slik jeg tolker det så bytter man digests med faktisk SemVer så det blir enklere å skjønne hvilken versjon vi bruker? 

Skal vi fortsette å ikke pinne digests på github og actions sine actions? (offisielle actions)

https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigeststosemver

I følge denne diskusjonen så skal dette være riktig ja: 

https://github.com/renovatebot/renovate/discussions/21901