### PR TITLE
Add support for custom base images hosted in private azure registry

### DIFF
--- a/ecosystem/auto.json
+++ b/ecosystem/auto.json
@@ -10,6 +10,7 @@
     "github>code-obos/dkt-renovate-presets//ecosystem/schedule-specific",
     "github>code-obos/dkt-renovate-presets//ecosystem/lock-file-maintenance",
     "github>code-obos/dkt-renovate-presets//ecosystem/host-rules",
+    "github>code-obos/dkt-renovate-presets//ecosystem/docker-image-azurecr",
     "workarounds:all"
   ]
 }

--- a/ecosystem/docker-image-azurecr.json
+++ b/ecosystem/docker-image-azurecr.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "dktprodacr.azurecr.io/*"
+      ],
+      "versioning": "semver",
+      "registryUrls": [
+        "https://dktprodacr.azurecr.io"
+      ]
+    }
+  ]
+}

--- a/ecosystem/host-rules.json
+++ b/ecosystem/host-rules.json
@@ -5,6 +5,12 @@
       "matchHost": "https://npm.pkg.github.com/",
       "hostType": "npm",
       "token": "{{ secrets.RENOVATE_GITHUB_REGISTRY_TOKEN }}"
+    },
+    {
+      "matchHost": "dktprodacr.azurecr.io",
+      "hostType": "docker",
+      "username": "renovate",
+      "password": "{{ secrets.RENOVATE_AZURE_REGISTRY_TOKEN }}"
     }
   ]
 }


### PR DESCRIPTION
Legger inn støtte for at renovate kan holde interne docker base images oppdatert hos konsumentene. 


- [x] Få noen i cloud platform til å legge inn tokenet i organization secrets