### PR TITLE
add tailwind postcss packages to design system packages

### DIFF
--- a/ecosystem/group-by-pattern.json
+++ b/ecosystem/group-by-pattern.json
@@ -30,7 +30,12 @@
       "groupName": "happy-dom packages"
     },
     {
-      "matchPackagePatterns": ["^@obosbbl/grunnmuren-", "^tailwindcss"],
+      "matchPackagePatterns": [
+        "^@obosbbl/grunnmuren-",
+        "^tailwindcss",
+        "^@tailwindcss",
+        "^postcss"
+      ],
       "groupName": "design system packages"
     },
     {


### PR DESCRIPTION
føler disse henger sammen? eller tenker vi kanskje å bare kjøre postcss-pakkene sammen 🤔 

endringen legger inn `postcss` og `@tailwindcss/postcss` pakkene til design system packages gruppa