### PR TITLE
Add support for terraform modules hosted in spacelift private registry

### DIFF
--- a/ecosystem/auto.json
+++ b/ecosystem/auto.json
@@ -11,6 +11,7 @@
     "github>code-obos/dkt-renovate-presets//ecosystem/lock-file-maintenance",
     "github>code-obos/dkt-renovate-presets//ecosystem/host-rules",
     "github>code-obos/dkt-renovate-presets//ecosystem/docker-image-azurecr",
+    "github>code-obos/dkt-renovate-presets//ecosystem/terraform-spacelift",
     "workarounds:all"
   ]
 }

--- a/ecosystem/host-rules.json
+++ b/ecosystem/host-rules.json
@@ -11,6 +11,11 @@
       "hostType": "docker",
       "username": "renovate",
       "password": "{{ secrets.RENOVATE_AZURE_REGISTRY_TOKEN }}"
+    },
+    {
+      "matchHost": "spacelift.io",
+      "hostType": "terraform",
+      "token": "{{ secrets.RENOVATE_SPACELIFT_REGISTRY_TOKEN }}"
     }
   ]
 }

--- a/ecosystem/terraform-spacelift.json
+++ b/ecosystem/terraform-spacelift.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"terraform": {
+		"enabled": true
+	}
+}


### PR DESCRIPTION
Legger inn støtte for å lese moduler fra vårt private register hos spacelift.io. 

Ref: 
<img width="929" height="372" alt="image" src="https://github.com/user-attachments/assets/a6f7e3b4-ba97-4d4a-b0b5-e066fd9d5421" />

https://github.com/code-obos/blokk-backenddemo-infra/issues/2