### PR TITLE
Schedule all depTypes to run before 6am on saturdays

### DIFF
--- a/ecosystem/schedule.json
+++ b/ecosystem/schedule.json
@@ -7,19 +7,11 @@
   "packageRules": [
     {
       "matchDepTypes": [
-        "dependencies",
-        "devDependencies",
-        "peerDependencies",
-        "resolutions",
-        "action",
-        "final",
-        "required_provider",
-        "packageManager",
-        "volta",
-        "engines",
-        "uses-with"
+        "*"
       ],
-      "schedule": ["before 6am on Saturday"]
+      "schedule": [
+        "before 6am on Saturday"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Fix depTypes not running on pnpm catalogs, since its not running on obos-nettsider atm

står i en bisetning: https://docs.renovatebot.com/modules/manager/npm/#dependency-types